### PR TITLE
Fixing test_runtime.sh command line for PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Testing OCI runtimes
 ```
 $ make
 $ sudo make install
-$ sudo ./test_runtime.sh -r runc
+$ sudo env "PATH=$PATH" ./test_runtime.sh -r runc
 -----------------------------------------------------------------------------------
 VALIDATING RUNTIME: runc
 -----------------------------------------------------------------------------------


### PR DESCRIPTION
PATH doesn't carry through for sudo all the time. It depends how sudo is organized. Forcing PATH into the command line fixes this problem.