### PR TITLE
Changed TESTCMD from "start" to "run".

### DIFF
--- a/test_runtime.sh
+++ b/test_runtime.sh
@@ -68,7 +68,7 @@ pushd $TESTDIR > /dev/null
 ocitools generate --args /runtimetest --rootfs ""
 popd > /dev/null
 
-TESTCMD="${RUNTIME} start"
+TESTCMD="${RUNTIME} run"
 pushd $TESTDIR > /dev/null
 if ! ${TESTCMD}; then
 	error "Runtime ${RUNTIME} failed validation"


### PR DESCRIPTION
The start command can only happen on a created container according to the spec, or it MUST error out. The run command creates then starts the container.